### PR TITLE
Fixed lives not resetting after loss

### DIFF
--- a/guess.py
+++ b/guess.py
@@ -83,6 +83,7 @@ def play_preparation():
 	play(word,length,visual_list)
 
 def menu():
+	global life
 	clearscreen()
 	print()
 	print("      MENU       ")


### PR DESCRIPTION
Lives don't reset after loss, this was pointed out in an issue. The issue was that you were creating lives as a local variable in the menu function instead of overwriting existing global variable. Fixed by declaring lives as a global variable.